### PR TITLE
common.sh: fix return code of log_debug with enabled DINIT_EARLY_DEBUG

### DIFF
--- a/early/scripts/common.sh
+++ b/early/scripts/common.sh
@@ -9,7 +9,9 @@ export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 log_debug() {
     [ -n "$DINIT_EARLY_DEBUG" ] || return 0
     echo "INIT:" "$@"
-    [ -n "$DINIT_EARLY_DEBUG_SLOW" ] && sleep "$DINIT_EARLY_DEBUG_SLOW"
+    if [ -n "$DINIT_EARLY_DEBUG_SLOW" ]; then
+        sleep "$DINIT_EARLY_DEBUG_SLOW"
+    fi
 }
 
 # if requested, append all to logfile


### PR DESCRIPTION
The one line check of `DINIT_EARLY_DEBUG_SLOW` being set (without a proper if-statement) made `log_debug()` return 1 and when scripts like `cgroups.sh` with `set -e` before sourcing `common.sh` made them "just fail"

Fixes #17.