### PR TITLE
pseudofs.sh: try and mount /sys/fs/selinux

### DIFF
--- a/early/scripts/pseudofs.sh
+++ b/early/scripts/pseudofs.sh
@@ -36,3 +36,7 @@ fi
 if [ -d /sys/firmware/efi/efivars ]; then
     mntpt /sys/firmware/efi/efivars || mount -o nosuid,noexec,nodev -t efivarfs efivarfs /sys/firmware/efi/efivars
 fi
+
+if [ -d /sys/fs/selinux ]; then
+    mntpt /sys/fs/selinux || mount -t selinuxfs selinuxfs /sys/fs/selinux
+fi


### PR DESCRIPTION
Not sure if this is wanted here, but I saw you mentioned the possibility of dinit-chimera becoming a "base" general dinit service suite. For people that don't use SELinux, this should make no difference, otherwise just try and mount /sys/fs/selinux.