### PR TITLE
devmon: include cstring for std::strcmp

### DIFF
--- a/early/helpers/devmon.cc
+++ b/early/helpers/devmon.cc
@@ -52,6 +52,7 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstdio>
+#include <cstring>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
Fixes compilation with GCC.