### PR TITLE
Add zram service

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ exit with success if the tools aren't located.
   * For kernel crashdump support
 * [kexec-tools](https://kernel.org/pub/linux/utils/kernel/kexec)
   * For kernel crashdump support
+* `zramctl`, `mkswap`, `swapon`, `swapoff` from `util-linux`
+  * For ZRAM swap support
 
 ## Kernel command line
 

--- a/early/scripts/zram.sh
+++ b/early/scripts/zram.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+DINIT_SERVICE=zram
+DINIT_NO_CONTAINER=1
+
+set -eu
+
+# default settings
+RAM_PERCENTAGE=100
+MAX_SIZE_MB=8192
+ALGORITHM=lzo-rle
+[ -f "/etc/default/zram" ] && . /etc/default/zram
+
+STATUS_FILE=/run/zram-swap-device
+
+get_total_memory_kb() {
+    grep MemTotal: /proc/meminfo | cut -w -f2
+}
+
+calculate_swap_size_kb() {
+    total_memory_kb=$(get_total_memory_kb)
+    a=$(( total_memory_kb * RAM_PERCENTAGE / 100 ))
+    b=$(( MAX_SIZE_MB * 1024 ))
+    echo $(( a < b ? a : b ))
+}
+
+stop() {
+    dev="$(cat $STATUS_FILE)"
+    swapoff "$dev" || true
+    zramctl --reset "$dev"
+    rm "$STATUS_FILE"
+}
+
+start() {
+    modprobe zram
+    size="$(calculate_swap_size_kb)K"
+    dev=$(zramctl --find --size "$size" --algorithm "$ALGORITHM")
+    echo "$dev" > "$STATUS_FILE"
+    mkswap -U clear "$dev"
+    swapon --priority 100 "$dev"
+}
+
+case "$@" in
+    start)
+        start
+        ;;
+    stop)
+        [ -f "$STATUS_FILE" ] && stop
+        ;;
+    *)
+        echo "Usage: $0 start|stop"
+esac

--- a/services/zram
+++ b/services/zram
@@ -1,0 +1,7 @@
+# zram swap
+
+type = scripted
+command = @SCRIPT_PATH@/zram.sh start
+stop-command = @SCRIPT_PATH@/zram.sh stop
+depends-on = early-fs-local.target
+before = pre-local.target


### PR DESCRIPTION
See #9. I made this a few months ago and then, uh, didn't do anything with it till now. I tried to keep it simple but still support setting a percentage of RAM, to have sensible default settings. The defaults (100% of RAM up to 8GB) are what Fedora uses.

By default ZRAM is off but can be enabled by enabling the service. I couldn't figure out if this should technically be `early-zram` so I called it `zram` because that's a more obvious name to enable it by hand.